### PR TITLE
Double vinculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,43 @@ $ cargo run I̅V̅DCCXI
 4711
 ```
 
+## Number mappings
+
+Normal roman numerals:
+|Numeral|Arabic|
+|-------|------|
+|I | 1 |
+|V | 5 |
+|X | 10 |
+|L | 50 |
+|C | 100 |
+|D | 500 |
+|M | 1000 |
+
+Single vinculum (reaches up to a million):
+|Numeral|Arabic|Power of ten|
+|-------|------|------------|
+|I̅ | 1000 |10^3|
+|V̅ | 5000 ||
+|X̅ | 10.000 |10^4|
+|L̅ | 50.000 ||
+|C̅ | 100.000 |10^5|
+|D̅ | 500.000 ||
+|M̅ | 1.000.000 |10^6|
+
+
+Double vinculum (up to a billion):
+|Numeral|Arabic|Power of ten|
+|-------|------|------------|
+|I̿ | 1.000.000 |10^6|
+|V̿ | 5.000.000 ||
+|X̿ | 10.000.000 |10^7|
+|L̿ | 50.000.000 ||
+|C̿ | 100.000.000 |10^8|
+|D̿ | 500.000.000 ||
+|M̿ | 1.000.000.000 |10^9|
+
+
 ## TODO
 
 * add support for double vinculums

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,8 @@ This function is separate from the smaller powers of ten because
 it is only partially compliant with the rules for roman numerals.
 The largest supported number is 3.999.999 but we'll allow bigger numbers here.
 */
-fn make_vinculum_billion(times: &u64) -> Result<String, String> {
-    let mut result = String::new();
-    for _ in 0..*times {
-        result.push_str("M̿");
-    }
-    Ok(result)
+fn make_vinculum_billion(times: u64) -> String {
+    std::iter::repeat('M̿').take(times).collect()
 }
 
 fn make_vinculum(times: &u64, char1: &str, char5: &str, char10: &str) -> Result<String, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub fn arabic2vinculum(input: u64) -> Result<String, String>  {
     let mut result = String::new();
     let mut arabic = input.clone();
 
-    // From 1_000_000 to 10 in steps of powers of ten:
-    for n in (1..=6).rev() {
+    // From 1_000_000_000 to 10 in steps of powers of ten:
+    for n in (1..=9).rev() {
         let divisor = 10_u32.pow(n);
         let divided: u64 = arabic / divisor as u64;
         if divided > 0 {
@@ -55,16 +55,20 @@ pub fn vinculum2arabic<S: AsRef<str>>(input: S) -> Result<u64, String> {
 
 fn make_vinculum_number(divisor: &u32, times: &u64) -> Result<String, String>
 {
+    println!("Divisor: {} times {}", divisor, times);
     match divisor {
-        1000000 => make_vinculum_million(times),
-        100000 => make_vinculum(times, "C̅", "D̅", "CM̅"),
+        1000000000 => make_vinculum_billion(times),
+        100000000 => make_vinculum(times, "C̿", "D̿", "M̿"),
+        10000000 => make_vinculum(times, "X̿", "L̿", "C̿"),
+        1000000 => make_vinculum(times, "M̅", "V̿", "X̿"),
+        100000 => make_vinculum(times, "C̅", "D̅", "M̅"),
         10000 => make_vinculum(times, "X̅", "L̅", "C̅"),
         1000 => make_vinculum(times, "I̅", "V̅", "X̅"),
         100 => make_vinculum(times, "C", "D", "I̅"),
         10 => make_vinculum(times, "X", "L", "C"),
         1 => make_vinculum(times, "I", "V", "X"),
         _ => {
-            let mut warning = String::from("Unsupported number: ");
+            let mut warning = String::from("Unsupported divisor: ");
             warning.push_str(&times.to_string());
             Err(warning)
         }
@@ -76,10 +80,10 @@ This function is separate from the smaller powers of ten because
 it is only partially compliant with the rules for roman numerals.
 The largest supported number is 3.999.999 but we'll allow bigger numbers here.
 */
-fn make_vinculum_million(times: &u64) -> Result<String, String> {
+fn make_vinculum_billion(times: &u64) -> Result<String, String> {
     let mut result = String::new();
-    for n in 0..*times {
-        result.push_str("M̅");
+    for _ in 0..*times {
+        result.push_str("M̿");
     }
     Ok(result)
 }
@@ -226,14 +230,20 @@ mod tests {
     }
 
     #[test]
+    fn test_arabic2vinculum_double_vinculum() {
+        assert_eq!(arabic2vinculum(5000000).unwrap(), "V̿");
+        assert_eq!(arabic2vinculum(10000000).unwrap(), "X̿");
+        assert_eq!(arabic2vinculum(50000000).unwrap(), "L̿");
+        assert_eq!(arabic2vinculum(100000000).unwrap(), "C̿");
+        assert_eq!(arabic2vinculum(500000000).unwrap(), "D̿");
+        assert_eq!(arabic2vinculum(1000000000).unwrap(), "M̿");
+    }
+
+    #[test]
     fn test_arabic2vinculum_irregular_numbers() {
         // for numbers which aren't actually valid roman numbers,
         // not even by vinculum's standards LOL
-        assert_eq!(arabic2vinculum(4000000).unwrap(), "M̅M̅M̅M̅");
-        assert_eq!(arabic2vinculum(5000000).unwrap(), "M̅M̅M̅M̅M̅");
-        assert_eq!(arabic2vinculum(15000000).unwrap(), "M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅M̅");
-        // Largest possible number:
-        // 18446744073709551615
+        assert_eq!(arabic2vinculum(4000000000).unwrap(), "M̿M̿M̿M̿");
     }
 
     // # TODO

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,7 @@ fn make_vinculum_number(divisor: &u32, times: &u64) -> Result<String, String>
         10 => make_vinculum(times, "X", "L", "C"),
         1 => make_vinculum(times, "I", "V", "X"),
         _ => {
-            let mut warning = String::from("Unsupported divisor: ");
-            warning.push_str(&times.to_string());
-            Err(warning)
+            Err(format!("Unsupported divisor: {}", times))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ pub fn arabic2vinculum(input: u64) -> Result<String, String>  {
 
     // From 1_000_000_000 to 10 in steps of powers of ten:
     for n in (1..=9).rev() {
-        let divisor = 10_u32.pow(n);
-        let divided: u64 = arabic / divisor as u64;
+        let divisor: u64 = 10_u64.pow(n);
+        let divided: u64 = arabic / divisor;
         if divided > 0 {
             let appendix = make_vinculum_number(&divisor, &divided).unwrap();
             result.push_str(&appendix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ pub fn vinculum2arabic<S: AsRef<str>>(input: S) -> Result<u64, String> {
 
 fn make_vinculum_number(divisor: &u32, times: &u64) -> Result<String, String>
 {
-    println!("Divisor: {} times {}", divisor, times);
     match divisor {
         1000000000 => make_vinculum_billion(times),
         100000000 => make_vinculum(times, "C̿", "D̿", "M̿"),


### PR DESCRIPTION
This PR introduces double vinculums, which allows to translate numbers up to a billion (previously: a million) into vinculum representations.